### PR TITLE
Remove broken link to html5shim

### DIFF
--- a/_includes/default.html
+++ b/_includes/default.html
@@ -11,11 +11,6 @@
 	<!-- Enable responsive viewport -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-	<!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-	<!--[if lt IE 9]>
-	<script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-	<![endif]-->
-
 	<!-- Le styles -->
 	<link href="{{ site.BASE_PATH }}/assets/resources/bootstrap/css/bootstrap.min.css" rel="stylesheet">
 	<link href="{{ site.BASE_PATH }}/assets/resources/font-awesome/css/font-awesome.min.css" rel="stylesheet">


### PR DESCRIPTION
Drops support for IE6-8

The link http://html5shim.googlecode.com/svn/trunk/html5.js doesn't work anymore. Let's remove it.